### PR TITLE
Dev/frank/35217

### DIFF
--- a/ports/cimg/CMakeLists.txt
+++ b/ports/cimg/CMakeLists.txt
@@ -19,3 +19,7 @@ install(
     FILES ${CMAKE_CURRENT_SOURCE_DIR}/CImg.h
     DESTINATION include
 )
+
+install(
+    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/plugins DESTINATION include)
+

--- a/ports/cimg/portfile.cmake
+++ b/ports/cimg/portfile.cmake
@@ -1,7 +1,8 @@
+
 vcpkg_from_github(OUT_SOURCE_PATH SOURCE_PATH
     REPO dtschump/CImg
-    REF b33dcc8f9f1acf1f276ded92c04f8231f6c23fcd # v2.9.9
-    SHA512 327c72320e7cac386ba72d417c45b9e8b40df34650370c34e687c362731919af1b447b2ee498f21278d4af155f0d9dbfabd222856d5f18c2e05569fa638a5909
+    REF d6c022169271fa3c73abf94002a557c4e6f8327f #v3.3.2
+    SHA512 0cb2e0cc41902bdb3a21bac079104d4c49bbf51ae0eef6497fdb645934311aa75480bffcc2fc9d11c5b54912397fb4910c4c20ccd766a83e317a8e861b9b513b
     HEAD_REF master
 )
 
@@ -17,5 +18,8 @@ vcpkg_cmake_install()
 file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 
-file(INSTALL "${SOURCE_PATH}/Licence_CeCILL-C_V1-en.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-file(INSTALL "${SOURCE_PATH}/Licence_CeCILL_V2-en.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright2)
+vcpkg_install_copyright(
+    FILE_LIST 
+        "${SOURCE_PATH}/Licence_CeCILL-C_V1-en.txt"
+        "${SOURCE_PATH}/Licence_CeCILL_V2-en.txt"
+)

--- a/ports/cimg/vcpkg.json
+++ b/ports/cimg/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cimg",
-  "version": "2.9.9",
+  "version": "3.3.2",
   "description": "The CImg Library is a small, open-source, and modern C++ toolkit for image processing",
   "homepage": "https://github.com/dtschump/CImg",
   "dependencies": [

--- a/ports/libslirp/fix-osx.patch
+++ b/ports/libslirp/fix-osx.patch
@@ -1,5 +1,5 @@
 diff --git a/meson.build b/meson.build
-index 5605dc9..bcbcd16 100644
+index 5605dc9..968edfb 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -117,6 +117,10 @@ if cc.has_link_argument(vflag_test)
@@ -8,7 +8,7 @@ index 5605dc9..bcbcd16 100644
  
 +if host_system == 'darwin'
 +    vflag += '-framework CoreFoundation -framework AppKit -framework Carbon'
-+endif()
++endif
 +
  install_devel = not meson.is_subproject()
  

--- a/ports/libslirp/fix-osx.patch
+++ b/ports/libslirp/fix-osx.patch
@@ -1,0 +1,15 @@
+diff --git a/meson.build b/meson.build
+index 5605dc9..bcbcd16 100644
+--- a/meson.build
++++ b/meson.build
+@@ -117,6 +117,10 @@ if cc.has_link_argument(vflag_test)
+   vflag += vflag_test
+ endif
+ 
++if host_system == 'darwin'
++    vflag += '-framework CoreFoundation -framework AppKit -framework Carbon'
++endif()
++
+ install_devel = not meson.is_subproject()
+ 
+ configure_file(

--- a/ports/libslirp/portfile.cmake
+++ b/ports/libslirp/portfile.cmake
@@ -5,6 +5,8 @@ vcpkg_from_gitlab(
     REF v4.7.0
     SHA512 387f4a6dad240ce633df2640bb49c6cb0041c8b3afc8d0ef38186d385f00dd9e4ef4443e93e1b71dbf05e22892b6f2771a87a202e815d8ec899ab5c147a1f09f
     HEAD_REF master
+    PATCHES
+        fix-osx.patch
 )
 
 if(VCPKG_HOST_IS_WINDOWS)
@@ -24,4 +26,5 @@ vcpkg_fixup_pkgconfig()
 
 vcpkg_copy_pdbs()
 
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 file(INSTALL "${SOURCE_PATH}/COPYRIGHT" DESTINATION "${CURRENT_PACKAGES_DIR}/share/libslirp" RENAME copyright)

--- a/ports/libslirp/usage
+++ b/ports/libslirp/usage
@@ -1,0 +1,5 @@
+slirp can be imported via CMake FindPkgConfig module:
+
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(Slirp REQUIRED IMPORTED_TARGET slirp)
+    target_link_libraries(slirp-test PRIVATE PkgConfig::Slirp)

--- a/ports/libslirp/vcpkg.json
+++ b/ports/libslirp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libslirp",
   "version-semver": "4.7.0",
+  "port-version": 1,
   "description": "libslirp is a user-mode networking library used by virtual machines, containers or various tools.",
   "homepage": "https://gitlab.freedesktop.org/slirp/libslirp",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1573,7 +1573,7 @@
       "port-version": 0
     },
     "cimg": {
-      "baseline": "2.9.9",
+      "baseline": "3.3.2",
       "port-version": 0
     },
     "cista": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4754,7 +4754,7 @@
     },
     "libslirp": {
       "baseline": "4.7.0",
-      "port-version": 0
+      "port-version": 1
     },
     "libsm": {
       "baseline": "1.2.3",

--- a/versions/c-/cimg.json
+++ b/versions/c-/cimg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aa3a7f6664a72a9c74b840e065abdd184655939a",
+      "version": "3.3.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "2eac332b873f6a2b9108c3e71e59feec8efe5026",
       "version": "2.9.9",
       "port-version": 0

--- a/versions/l-/libslirp.json
+++ b/versions/l-/libslirp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8cfef69e0b0596d37866815c21adb0daa190d7b6",
+      "git-tree": "39a62e66eeef4b2ad36c679ce5ccdd854b3d9920",
       "version-semver": "4.7.0",
       "port-version": 1
     },

--- a/versions/l-/libslirp.json
+++ b/versions/l-/libslirp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8cfef69e0b0596d37866815c21adb0daa190d7b6",
+      "version-semver": "4.7.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "6946f40e08a89013e998d3bf397613bdf08cb581",
       "version-semver": "4.7.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
