### PR TITLE
Dev/frank/43468

### DIFF
--- a/ports/llgi/fix-cmake-use-vcpkg.patch
+++ b/ports/llgi/fix-cmake-use-vcpkg.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 30cb2da..dbc051b 100644
+index 5fd2ce0..976b845 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -232,8 +232,13 @@ if(BUILD_VULKAN_COMPILER OR BUILD_TOOL)
+@@ -234,8 +234,13 @@ if(BUILD_VULKAN_COMPILER OR BUILD_TOOL)
        spirv-cross-util)
  
    else()
@@ -19,7 +19,7 @@ index 30cb2da..dbc051b 100644
    endif()
  
 diff --git a/tools/ShaderTranspilerCore/CMakeLists.txt b/tools/ShaderTranspilerCore/CMakeLists.txt
-index 4ce40d4..d4950ce 100644
+index bf34437..09e428d 100644
 --- a/tools/ShaderTranspilerCore/CMakeLists.txt
 +++ b/tools/ShaderTranspilerCore/CMakeLists.txt
 @@ -24,6 +24,10 @@ else()
@@ -27,23 +27,9 @@ index 4ce40d4..d4950ce 100644
  endif()
  
 +target_link_libraries(ShaderTranspilerCore PUBLIC
-+  glslang::glslang glslang::SPIRV glslang::OSDependent glslang::MachineIndependent glslang::GenericCodeGen glslang::glslang-default-resource-limits glslang::OGLCompiler glslang::SPVRemapper glslang::HLSL
-+  spirv-cross-cpp spirv-cross-glsl spirv-cross-msl spirv-cross-hlsl
++  glslang::glslang glslang::glslang-default-resource-limits glslang::SPIRV glslang::SPVRemapper spirv-cross-cpp spirv-cross-glsl spirv-cross-msl spirv-cross-hlsl
 +)
++
  if(USE_THIRDPARTY_DIRECTORY)
    add_dependencies(ShaderTranspilerCore EP_glslang EP_SPIRV-Cross)
  endif()
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index dbc051b..b898b4c 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -27,9 +27,6 @@ option(SPIRVCROSS_WITHOUT_INSTALL "Compile with spirv-cross without install"
-        OFF)
- option(USE_CREATE_COMPILER_FUNCTION "Whether LLGI::CreateCompiler is used." ON)
- 
--if(LINUX)
--  set(BUILD_VULKAN TRUE)
--endif()
- 
- option(USE_MSVC_RUNTIME_LIBRARY_DLL "compile as multithreaded DLL" ON)
- 

--- a/ports/llgi/portfile.cmake
+++ b/ports/llgi/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_from_github(
     SHA512 d521b47f293b90faed28f9648facdfae327c6122ea6391683a08e48558fdf62ce0d3977f78aef3bc276d77ab19fc40ab3cc4d27311dd5a292e0884635fe7c9d3
     HEAD_REF master
     PATCHES
-        fix-cmake-use-vcpkg.patch
+      #  fix-cmake-use-vcpkg.patch
         fix-sources.patch
 )
 

--- a/ports/llgi/vcpkg.json
+++ b/ports/llgi/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "llgi",
   "version-date": "2023-12-19",
+  "port-version": 1,
   "homepage": "https://github.com/altseed/LLGI",
   "license": null,
   "supports": "!(uwp | android)",

--- a/ports/salome-med-fichier/portfile.cmake
+++ b/ports/salome-med-fichier/portfile.cmake
@@ -3,9 +3,12 @@
 # med-fichier is needed to build all libraries of the https://www.salome-platform.org/ since it is the io 
 # entry point to open and read .med files.
 vcpkg_download_distfile(ARCHIVE
-  URLS "https://files.salome-platform.org/Salome/other/med-${VERSION}.tar.gz"
+  URLS "https://files.salome-platform.org/Salome/medfile/med-${VERSION}.tar.gz"
+  https://files.salome-platform.org/Salome/medfile/med-4.1.1.tar.gz
   FILENAME "med-${VERSION}.tar.gz"
-  SHA512 8917e7ecfe30e1259b0927c8e1c3d6efd86ed2386813f6d90217bd95589199478e587f0815031ab65cacf7901a30b77a6307414f9073caffe6e7f013e710d768
+  SHA512 f211fa82750a7cc935baa3a50a55d16e40117a0f2254b482492ba8396d82781ca84960995da7a16b2b5be0b93ce76368bf4b311bb8af0e5f0243e7051c9c554c
+  HEADERS 
+    "Referer: https://www.salome-platform.org/"
 )
 
 vcpkg_extract_source_archive(

--- a/ports/salome-med-fichier/portfile.cmake
+++ b/ports/salome-med-fichier/portfile.cmake
@@ -4,7 +4,6 @@
 # entry point to open and read .med files.
 vcpkg_download_distfile(ARCHIVE
   URLS "https://files.salome-platform.org/Salome/medfile/med-${VERSION}.tar.gz"
-  https://files.salome-platform.org/Salome/medfile/med-4.1.1.tar.gz
   FILENAME "med-${VERSION}.tar.gz"
   SHA512 f211fa82750a7cc935baa3a50a55d16e40117a0f2254b482492ba8396d82781ca84960995da7a16b2b5be0b93ce76368bf4b311bb8af0e5f0243e7051c9c554c
   HEADERS 

--- a/ports/salome-med-fichier/vcpkg.json
+++ b/ports/salome-med-fichier/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "salome-med-fichier",
   "version": "4.1.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "med-fichier provides a low level C API for fine-grained access to the structure of MED files (.med)",
   "homepage": "https://www.salome-platform.org",
   "license": "LGPL-3.0-or-later",

--- a/ports/simpleble/portfile.cmake
+++ b/ports/simpleble/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     REPO OpenBluetoothToolbox/SimpleBLE
     HEAD_REF main
     REF a07397dbdd7f8149b7b235b5b21b88b60e8cfbed
-    SHA512 f9bdb668da151dbc2335b9cfd17a130fdefb349e57e9ff3a270e1c0cc8b7ad1bfdf03704cd1e2c1c7c8b34f44684aa2bf649c14666c2c6fd9ea0ddad1e6bc8a3
+    SHA512 19b61093f529c37f6309c51b53499d86c45a7c3e2e6e8c619c191e40dac713ec1dafdf2a21f81bb9cb9ba6254ab226bd331ee7582facb84ef7756824ffa3eaa8
 )
 
 vcpkg_cmake_configure(

--- a/ports/simpleble/vcpkg.json
+++ b/ports/simpleble/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "simpleble",
   "version-date": "2023-07-29",
+  "port-version": 1,
   "description": "The ultimate fully-fledged cross-platform library and bindings for Bluetooth Low Energy (BLE).",
   "homepage": "https://github.com/OpenBluetoothToolbox/SimpleBLE",
   "license": "MIT",

--- a/ports/simpleble/vcpkg.json
+++ b/ports/simpleble/vcpkg.json
@@ -7,6 +7,10 @@
   "license": "MIT",
   "supports": "!android & !uwp",
   "dependencies": [
+    {
+      "name": "dbus",
+      "platform": "linux"
+    },
     "fmt",
     {
       "name": "vcpkg-cmake",

--- a/ports/spaceland/portfile.cmake
+++ b/ports/spaceland/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "http://vic.crs4.it/vic/download/pkgs/sl-7.8.2-Source.tar.gz"
+    URLS "https://www.crs4.it/vic/download/pkgs/sl-7.8.2-Source.tar.gz"
     FILENAME "sl-7.8.2-Source.tar.gz"
     SHA512 1391dac1474ddb47d0cf0eb7baeb7db68d6356c2116f732dd57b8a050739523282ded0643cc466640f2b22f25dd6bfced00ede4e041b7ff83754a99ae6725d7d
 )

--- a/ports/spaceland/vcpkg.json
+++ b/ports/spaceland/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "spaceland",
   "version": "7.8.2",
-  "port-version": 9,
+  "port-version": 10,
   "description": "Spaceland Lib (sl) is a suite for geometric computation, specifically adapted to OpenGL.",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5562,7 +5562,7 @@
     },
     "llgi": {
       "baseline": "2023-12-19",
-      "port-version": 0
+      "port-version": 1
     },
     "llgl": {
       "baseline": "2023-03-05",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8146,7 +8146,7 @@
     },
     "salome-med-fichier": {
       "baseline": "4.1.1",
-      "port-version": 1
+      "port-version": 2
     },
     "salome-medcoupling": {
       "baseline": "9.10.0",
@@ -8430,7 +8430,7 @@
     },
     "simpleble": {
       "baseline": "2023-07-29",
-      "port-version": 0
+      "port-version": 1
     },
     "simpleini": {
       "baseline": "4.22",
@@ -8570,7 +8570,7 @@
     },
     "spaceland": {
       "baseline": "7.8.2",
-      "port-version": 9
+      "port-version": 10
     },
     "span-lite": {
       "baseline": "0.11.0",

--- a/versions/l-/llgi.json
+++ b/versions/l-/llgi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "daf617dfd2d6841cad4c9beaa7ed2ccb393bde84",
+      "version-date": "2023-12-19",
+      "port-version": 1
+    },
+    {
       "git-tree": "70bc60ef323833846200e1ffe0937de2cfaaf77e",
       "version-date": "2023-12-19",
       "port-version": 0

--- a/versions/s-/salome-med-fichier.json
+++ b/versions/s-/salome-med-fichier.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8c51ceb14d3757cf80d07aebed3e2f4e8c03d6e5",
+      "git-tree": "daea12449180ff249e8bd85ba30cdc20d69ae5c8",
       "version": "4.1.1",
       "port-version": 2
     },

--- a/versions/s-/salome-med-fichier.json
+++ b/versions/s-/salome-med-fichier.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8c51ceb14d3757cf80d07aebed3e2f4e8c03d6e5",
+      "version": "4.1.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "26a3c208d3498e3c40c3f423f2493d1df53d49db",
       "version": "4.1.1",
       "port-version": 1

--- a/versions/s-/simpleble.json
+++ b/versions/s-/simpleble.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6f801cb49c3f9989d266973b9740241442e793de",
+      "git-tree": "f09680916652ad54c2b0483d86617130aaeed005",
       "version-date": "2023-07-29",
       "port-version": 1
     },

--- a/versions/s-/simpleble.json
+++ b/versions/s-/simpleble.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6f801cb49c3f9989d266973b9740241442e793de",
+      "version-date": "2023-07-29",
+      "port-version": 1
+    },
+    {
       "git-tree": "40042ec8c4a3d070cda1fd27f4ed5fc931219e3e",
       "version-date": "2023-07-29",
       "port-version": 0

--- a/versions/s-/spaceland.json
+++ b/versions/s-/spaceland.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b63d4ef664c1c2e13dfa609c8434b66ea9f5a3e5",
+      "version": "7.8.2",
+      "port-version": 10
+    },
+    {
       "git-tree": "c90ee76ea6a1d48d54be7f968df9a4847fd846de",
       "version": "7.8.2",
       "port-version": 9


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
